### PR TITLE
Fix for directory lookup and OSX specific files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ pip-log.txt
 *~
 *.save
 
+# OSX specific
+.DS_Store

--- a/lib/pubCrawlLib.py
+++ b/lib/pubCrawlLib.py
@@ -1469,7 +1469,7 @@ def parseDirectories(outDirs):
     docIds = [] # a list of tuples (docId, outDir)
     ignoreDocIds = []
     ignoreIssns = []
-    for srcDir in outDirs:
+    for srcDir, dirs, files in os.walk(outDirs):
         # do some basic checks on outDir
         if not isdir(srcDir):
             continue


### PR DESCRIPTION
Directory lookup didn't work on neither osx nor win/cygwin. This should help. Hopefully it doesn't break on linux.