### PR TITLE
Update pubCrossRef.py

### DIFF
--- a/lib/pubCrossRef.py
+++ b/lib/pubCrossRef.py
@@ -38,9 +38,13 @@ def lookupDoi(metaInfoDict, repeatCount=2, delaySecs=5):
     if httpResp==None:
         logging.debug("HTTPError while sending crossref request")
         return None
-
-    jsonStr = httpResp.read()
-    httpResp.close()
+    jsonStr = ""
+    try:
+        jsonStr = httpResp.read()
+        httpResp.close()
+    except:
+        logging.debug("sslError while reading httpResp")
+        return None
     xrdata = json.loads(jsonStr)
 
     # parse result


### PR DESCRIPTION
The httpResp.read() can sometimes broke down with the error message:
ssl.SSLError: ('The read operation timed out',)
and since I put this in the try / except module, I have to first create the jsonStr to avoid the UnboundLocalError
(↑ maybe this could be omit after I added the "return None",I didn't try it)